### PR TITLE
Fixed compile error that happens on Linux

### DIFF
--- a/src/egl.nim
+++ b/src/egl.nim
@@ -37,7 +37,7 @@ elif defined(android):
   {.pragma: eglImport, cdecl, importc.}
 
 elif defined(freebsd) or defined(linux) or defined(openbsd) or defined(unix):
-  import xlib, xutil
+  import x, xlib, xutil
 
   type
     EGLNativeDisplayType* = PXDisplay


### PR DESCRIPTION
Fixed following compile error:
egl.nim(44, 28) Error: undeclared identifier: 'TPixmap'