### PR TITLE
Fix EGLMustCastToProperProcType type

### DIFF
--- a/src/egl.nim
+++ b/src/egl.nim
@@ -81,7 +81,7 @@ type
 
 type
   EGLAttribList* = seq[EGLInt]
-  EGLMustCastToProperProcType* = proc ()
+  EGLMustCastToProperProcType* = pointer
 
 
 const


### PR DESCRIPTION
``proc ()`` type cannot be cast to ``proc () {.cdecl.}``.
``wglGetProcAddress`` and ``glXGetProcAddress`` in opengl module return ``pointer`` type value.
https://github.com/nim-lang/opengl/blob/master/src/opengl/private/prelude.nim